### PR TITLE
Fixed some minor typos in README.html

### DIFF
--- a/README.html
+++ b/README.html
@@ -494,11 +494,11 @@ Copyright (C) 2016 Slau Halatyn</p>
 <li>Speak and Select Previous Track: Control+P</li>
 <li>Speak and select Next Track: Control+; (semicolon)</li>
 <li>Speak and add Previous Track to Selection: Control+Shift+P</li>
-<li>Speak and add Next Track to Selection: Control+Shift+;(semicolon)</li>
-<li>Speak and retract Selection from Top Track: Control+Option+P (must be passed through)
-*Speak and retract Selection from Bottom Track: Control+Option+; (semicolon) (must be passed through)</li>
+<li>Speak and add Next Track to Selection: Control+Shift+; (semicolon)</li>
+<li>Speak and retract Selection from Top Track: Control+Option+P (must be passed through)</li>
+<li>Speak and retract Selection from Bottom Track: Control+Option+; (semicolon) (must be passed through)</li>
 <li>Speak/Toggle Metronome:   Option+num pad 7</li>
-<li>Speak/Toggle Count In:    Option+num pad8</li>
+<li>Speak/Toggle Count In:    Option+num pad 8</li>
 <li>Speak/Toggle Midi Merge:  Option+num pad 9</li>
 <li>Speak/Toggle Tab to Transients:   Command+Option+Tab</li>
 <li>Speak/Toggle Insertion Follows Playback:  Control+N</li>


### PR DESCRIPTION
Fixed some minor typos.

- Added a space between the semicolon symbol and the word semicolon in parentheses.
- Separated one list item for "Speak and retract Selection fro Top Track" and "Bottom Track" into two list items. 
- Added a space between "pad" and "8".